### PR TITLE
Auth access keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 /flamedb
+cmd/flamedb-access-key/flamedb-access-key

--- a/cmd/flamedb-access-key/main.go
+++ b/cmd/flamedb-access-key/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/myzie/flamedb/database"
+	"github.com/namsral/flag"
+)
+
+func fatal(msg string, err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err.Error())
+	} else {
+		fmt.Fprintf(os.Stderr, "%s\n", msg)
+	}
+	os.Exit(1)
+}
+
+func main() {
+
+	var (
+		name  string
+		refID string
+		perm  string
+	)
+
+	flag.StringVar(&name, "name", "", "Key name")
+	flag.StringVar(&refID, "ref", "", "Reference ID")
+	flag.StringVar(&perm, "perm", "rw", "Permission: r or rw")
+	flag.Parse()
+
+	if name == "" {
+		fatal("Please provide a key name using -name", nil)
+	}
+
+	gormDB, err := database.Connect(database.GetSettings())
+	if err != nil {
+		fatal("Failed to connect to database", err)
+	}
+	if err := gormDB.AutoMigrate(&database.AccessKey{}).Error; err != nil {
+		fatal("Failed to migrate database", err)
+	}
+
+	permission := database.AccessKeyPermission(perm)
+	key, plainText, err := database.NewAccessKey(name, refID, permission)
+	if err != nil {
+		fatal("Failed to generate access key", err)
+	}
+	if err := gormDB.Save(&key).Error; err != nil {
+		fatal("Failed to save access key", err)
+	}
+
+	var output = struct {
+		KeyID     string `json:"key_id"`
+		KeySecret string `json:"key_secret"`
+	}{
+		KeyID:     key.ID,
+		KeySecret: plainText,
+	}
+
+	js, err := json.Marshal(output)
+	if err != nil {
+		fatal("Failed to marshal output", err)
+	}
+
+	fmt.Printf("%s\n", string(js))
+}

--- a/database/access_keys.go
+++ b/database/access_keys.go
@@ -55,6 +55,8 @@ func NewAccessKey(name, refID string, perm AccessKeyPermission) (*AccessKey, str
 	switch perm {
 	case ReadOnly:
 	case ReadWrite:
+	case ServiceRead:
+	case ServiceReadWrite:
 	default:
 		return nil, "", errors.New("Invalid permission value")
 	}

--- a/database/access_keys.go
+++ b/database/access_keys.go
@@ -2,44 +2,87 @@ package database
 
 import (
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"time"
 
+	gorm "github.com/jinzhu/gorm"
+	"github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
+)
+
+// AccessKeyPermission defines the access level associated with an access key
+type AccessKeyPermission string
+
+const (
+	// Denied access
+	Denied AccessKeyPermission = ""
+
+	// ReadOnly grant
+	ReadOnly AccessKeyPermission = "r"
+
+	// ReadWrite grant
+	ReadWrite AccessKeyPermission = "rw"
+
+	// ServiceRead provides read access from an external service
+	ServiceRead AccessKeyPermission = "sr"
+
+	// ServiceReadWrite provides rw access from an external service
+	ServiceReadWrite AccessKeyPermission = "srw"
 )
 
 // AccessKey is a database entry allowing access to FlameDB
 type AccessKey struct {
-	ID        string    `json:"id" gorm:"size:64;primary_key;unique_index"`
-	Name      string    `json:"name" gorm:"size:64"`
-	CreatedAt time.Time `json:"created_at"`
-	Value     string    `json:"value" gorm:"size:100"`
+	ID         string    `json:"id" gorm:"size:64;primary_key;unique_index"`
+	RefID      string    `json:"ref_id" gorm:"size:64;index"`
+	Name       string    `json:"name" gorm:"size:64"`
+	Permission string    `json:"permission" gorm:"size:64"`
+	CreatedAt  time.Time `json:"created_at"`
+	Secret     string    `json:"value" gorm:"size:100"`
 }
 
 // Compare the given plaintext against this key to see if it's a match.
 // Returns nil if it matches.
 func (key *AccessKey) Compare(plaintext string) error {
-	return bcryptCompare(key.Value, plaintext)
+	return bcryptCompare(key.Secret, plaintext)
 }
 
 // NewAccessKey initializes a new AccessKey with a random secret value.
 // The AccessKey model is returned along with the plaintext value which
 // should be stored externally.
-func NewAccessKey(name string) (*AccessKey, string, error) {
+func NewAccessKey(name, refID string, perm AccessKeyPermission) (*AccessKey, string, error) {
 
-	value := NewID()
+	switch perm {
+	case ReadOnly:
+	case ReadWrite:
+	default:
+		return nil, "", errors.New("Invalid permission value")
+	}
 
-	cipher, err := bcryptHash(value)
+	keyID, err := uuid.NewV4()
+	if err != nil {
+		return nil, "", err
+	}
+
+	keySecret, err := uuid.NewV4()
+	if err != nil {
+		return nil, "", err
+	}
+
+	cipherText, err := bcryptHash(keySecret.String())
 	if err != nil {
 		return nil, "", err
 	}
 
 	key := AccessKey{
-		ID:        NewID(),
-		Name:      name,
-		CreatedAt: time.Now(),
-		Value:     cipher,
+		ID:         keyID.String(),
+		RefID:      refID,
+		Name:       name,
+		Permission: string(perm),
+		CreatedAt:  time.Now(),
+		Secret:     cipherText,
 	}
-	return &key, value, nil
+	return &key, keySecret.String(), nil
 }
 
 func bcryptHash(password string) (string, error) {
@@ -56,4 +99,34 @@ func bcryptCompare(hashedPassword, password string) error {
 		return err
 	}
 	return bcrypt.CompareHashAndPassword(hash, []byte(password))
+}
+
+// AccessKeyStore is an interface to retrieve access permissions
+type AccessKeyStore interface {
+
+	// Get returns the access key with the given key ID
+	Get(id string) (*AccessKey, error)
+}
+
+// NewAccessKeyStore returns an initialized access key store
+func NewAccessKeyStore(gormDB *gorm.DB) (AccessKeyStore, error) {
+
+	if err := gormDB.AutoMigrate(&AccessKey{}).Error; err != nil {
+		return nil, fmt.Errorf("Failed to migrate: %s", err.Error())
+	}
+
+	return &accessKeyStore{gormDB: gormDB}, nil
+}
+
+type accessKeyStore struct {
+	gormDB *gorm.DB
+}
+
+func (ks *accessKeyStore) Get(id string) (*AccessKey, error) {
+	// Retrieve the access key with that ID
+	key := &AccessKey{}
+	if err := ks.gormDB.Where(AccessKey{ID: id}).First(&key).Error; err != nil {
+		return nil, err
+	}
+	return key, nil
 }

--- a/database/access_keys_test.go
+++ b/database/access_keys_test.go
@@ -3,13 +3,14 @@ package database
 import (
 	"testing"
 
+	"github.com/myzie/flamedb/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccessKey(t *testing.T) {
 
-	key, text, err := NewAccessKey("my-key")
+	key, text, err := NewAccessKey("my-key", database.ReadOnly)
 	require.Nil(t, err)
 	require.NotNil(t, key)
 

--- a/database/access_keys_test.go
+++ b/database/access_keys_test.go
@@ -3,14 +3,13 @@ package database
 import (
 	"testing"
 
-	"github.com/myzie/flamedb/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccessKey(t *testing.T) {
 
-	key, text, err := NewAccessKey("my-key", database.ReadOnly)
+	key, text, err := NewAccessKey("my-key", "ref-id", ReadOnly)
 	require.Nil(t, err)
 	require.NotNil(t, key)
 

--- a/main.go
+++ b/main.go
@@ -81,10 +81,16 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	keyStore, err := database.NewAccessKeyStore(gormDB)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	service.New(service.Opts{
-		API:   api,
-		Flame: database.NewFlame(gormDB),
-		Key:   jwk,
+		API:            api,
+		Flame:          database.NewFlame(gormDB),
+		AccessKeyStore: keyStore,
+		Key:            jwk,
 	})
 
 	server.SetHandler(corsMiddleware.Handler(api.Serve(nil)))

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"crypto/rsa"
+	"net/http"
 	"strings"
 
 	"github.com/go-openapi/loads"
@@ -27,6 +29,14 @@ func getJwk(url string) *rsa.PublicKey {
 		log.Fatalln("JWKS is empty")
 	}
 	return keys[0]
+}
+
+func setupMiddleware(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := r.Header.Get("X-User-Id")
+		ctx := context.WithValue(r.Context(), service.ContextKeyUserID, userID)
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 func main() {
@@ -93,7 +103,7 @@ func main() {
 		Key:            jwk,
 	})
 
-	server.SetHandler(corsMiddleware.Handler(api.Serve(nil)))
+	server.SetHandler(corsMiddleware.Handler(api.Serve(setupMiddleware)))
 
 	log.Printf("Listening at %s:%d\n", addr, port)
 

--- a/models/principal.go
+++ b/models/principal.go
@@ -16,14 +16,11 @@ import (
 // swagger:model Principal
 type Principal struct {
 
-	// email
-	Email string `json:"email,omitempty"`
+	// is service
+	IsService bool `json:"is_service,omitempty"`
 
-	// name
-	Name string `json:"name,omitempty"`
-
-	// token
-	Token string `json:"token,omitempty"`
+	// permissions
+	Permissions string `json:"permissions,omitempty"`
 
 	// user id
 	UserID string `json:"user_id,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -186,6 +186,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/RecordInput"
             }
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
@@ -294,6 +300,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/RecordInput"
             }
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
@@ -304,9 +316,9 @@ func init() {
             }
           },
           "400": {
-            "description": "Validation exception",
+            "description": "Bad request",
             "schema": {
-              "$ref": "#/definitions/ValidationError"
+              "$ref": "#/definitions/BadRequest"
             }
           },
           "404": {
@@ -347,11 +359,23 @@ func init() {
             "name": "recordId",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
           "200": {
             "description": "Record deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
           },
           "404": {
             "description": "Record not found",
@@ -406,13 +430,10 @@ func init() {
     "Principal": {
       "type": "object",
       "properties": {
-        "email": {
-          "type": "string"
+        "is_service": {
+          "type": "boolean"
         },
-        "name": {
-          "type": "string"
-        },
-        "token": {
+        "permissions": {
           "type": "string"
         },
         "user_id": {
@@ -690,6 +711,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/RecordInput"
             }
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
@@ -798,6 +825,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/RecordInput"
             }
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
@@ -808,9 +841,9 @@ func init() {
             }
           },
           "400": {
-            "description": "Validation exception",
+            "description": "Bad request",
             "schema": {
-              "$ref": "#/definitions/ValidationError"
+              "$ref": "#/definitions/BadRequest"
             }
           },
           "404": {
@@ -851,11 +884,23 @@ func init() {
             "name": "recordId",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Override user ID",
+            "name": "X-User-ID",
+            "in": "header"
           }
         ],
         "responses": {
           "200": {
             "description": "Record deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
           },
           "404": {
             "description": "Record not found",
@@ -910,13 +955,10 @@ func init() {
     "Principal": {
       "type": "object",
       "properties": {
-        "email": {
-          "type": "string"
+        "is_service": {
+          "type": "boolean"
         },
-        "name": {
-          "type": "string"
-        },
-        "token": {
+        "permissions": {
           "type": "string"
         },
         "user_id": {

--- a/restapi/operations/records/create_record_parameters.go
+++ b/restapi/operations/records/create_record_parameters.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
+	strfmt "github.com/go-openapi/strfmt"
+
 	models "github.com/myzie/flamedb/models"
 )
 
@@ -32,6 +34,10 @@ type CreateRecordParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Override user ID
+	  In: header
+	*/
+	XUserID *string
 	/*Record to be created
 	  Required: true
 	  In: body
@@ -47,6 +53,10 @@ func (o *CreateRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 	var res []error
 
 	o.HTTPRequest = r
+
+	if err := o.bindXUserID(r.Header[http.CanonicalHeaderKey("X-User-ID")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -74,5 +84,22 @@ func (o *CreateRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (o *CreateRecordParams) bindXUserID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.XUserID = &raw
+
 	return nil
 }

--- a/restapi/operations/records/delete_record_parameters.go
+++ b/restapi/operations/records/delete_record_parameters.go
@@ -30,6 +30,10 @@ type DeleteRecordParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Override user ID
+	  In: header
+	*/
+	XUserID *string
 	/*ID of record to be updated
 	  Required: true
 	  In: path
@@ -46,6 +50,10 @@ func (o *DeleteRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	o.HTTPRequest = r
 
+	if err := o.bindXUserID(r.Header[http.CanonicalHeaderKey("X-User-ID")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rRecordID, rhkRecordID, _ := route.Params.GetOK("recordId")
 	if err := o.bindRecordID(rRecordID, rhkRecordID, route.Formats); err != nil {
 		res = append(res, err)
@@ -54,6 +62,23 @@ func (o *DeleteRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (o *DeleteRecordParams) bindXUserID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.XUserID = &raw
+
 	return nil
 }
 

--- a/restapi/operations/records/delete_record_responses.go
+++ b/restapi/operations/records/delete_record_responses.go
@@ -37,6 +37,50 @@ func (o *DeleteRecordOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 	rw.WriteHeader(200)
 }
 
+// DeleteRecordBadRequestCode is the HTTP code returned for type DeleteRecordBadRequest
+const DeleteRecordBadRequestCode int = 400
+
+/*DeleteRecordBadRequest Bad request
+
+swagger:response deleteRecordBadRequest
+*/
+type DeleteRecordBadRequest struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.BadRequest `json:"body,omitempty"`
+}
+
+// NewDeleteRecordBadRequest creates DeleteRecordBadRequest with default headers values
+func NewDeleteRecordBadRequest() *DeleteRecordBadRequest {
+
+	return &DeleteRecordBadRequest{}
+}
+
+// WithPayload adds the payload to the delete record bad request response
+func (o *DeleteRecordBadRequest) WithPayload(payload *models.BadRequest) *DeleteRecordBadRequest {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete record bad request response
+func (o *DeleteRecordBadRequest) SetPayload(payload *models.BadRequest) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteRecordBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(400)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // DeleteRecordNotFoundCode is the HTTP code returned for type DeleteRecordNotFound
 const DeleteRecordNotFoundCode int = 404
 

--- a/restapi/operations/records/update_record_parameters.go
+++ b/restapi/operations/records/update_record_parameters.go
@@ -34,6 +34,10 @@ type UpdateRecordParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Override user ID
+	  In: header
+	*/
+	XUserID *string
 	/*Record to be updated
 	  Required: true
 	  In: body
@@ -54,6 +58,10 @@ func (o *UpdateRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 	var res []error
 
 	o.HTTPRequest = r
+
+	if err := o.bindXUserID(r.Header[http.CanonicalHeaderKey("X-User-ID")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -86,6 +94,23 @@ func (o *UpdateRecordParams) BindRequest(r *http.Request, route *middleware.Matc
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (o *UpdateRecordParams) bindXUserID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.XUserID = &raw
+
 	return nil
 }
 

--- a/restapi/operations/records/update_record_responses.go
+++ b/restapi/operations/records/update_record_responses.go
@@ -60,7 +60,7 @@ func (o *UpdateRecordOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 // UpdateRecordBadRequestCode is the HTTP code returned for type UpdateRecordBadRequest
 const UpdateRecordBadRequestCode int = 400
 
-/*UpdateRecordBadRequest Validation exception
+/*UpdateRecordBadRequest Bad request
 
 swagger:response updateRecordBadRequest
 */
@@ -69,7 +69,7 @@ type UpdateRecordBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.ValidationError `json:"body,omitempty"`
+	Payload *models.BadRequest `json:"body,omitempty"`
 }
 
 // NewUpdateRecordBadRequest creates UpdateRecordBadRequest with default headers values
@@ -79,13 +79,13 @@ func NewUpdateRecordBadRequest() *UpdateRecordBadRequest {
 }
 
 // WithPayload adds the payload to the update record bad request response
-func (o *UpdateRecordBadRequest) WithPayload(payload *models.ValidationError) *UpdateRecordBadRequest {
+func (o *UpdateRecordBadRequest) WithPayload(payload *models.BadRequest) *UpdateRecordBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update record bad request response
-func (o *UpdateRecordBadRequest) SetPayload(payload *models.ValidationError) {
+func (o *UpdateRecordBadRequest) SetPayload(payload *models.BadRequest) {
 	o.Payload = payload
 }
 

--- a/service/jwt.go
+++ b/service/jwt.go
@@ -8,23 +8,16 @@ import (
 	"github.com/myzie/flamedb/models"
 )
 
-// CustomClaims contained within a JWT
-type CustomClaims struct {
-	Email string `json:"email"`
-	Name  string `json:"name"`
-	jwt.StandardClaims
-}
-
 func parseJWT(key *rsa.PublicKey, tokenStr string) (*models.Principal, error) {
 
-	token, err := jwt.ParseWithClaims(tokenStr, &CustomClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		return key, nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	claims, ok := token.Claims.(*CustomClaims)
+	claims, ok := token.Claims.(*jwt.StandardClaims)
 	if !ok {
 		return nil, errors.New("Unknown JWT claims type")
 	}
@@ -33,9 +26,7 @@ func parseJWT(key *rsa.PublicKey, tokenStr string) (*models.Principal, error) {
 	}
 
 	return &models.Principal{
-		Email:  claims.Email,
-		Name:   claims.Name,
-		UserID: claims.Subject,
-		Token:  tokenStr,
+		UserID:      claims.Subject,
+		Permissions: "rw",
 	}, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ContextKey is a type used for storing values in a context
+type ContextKey int
+
+const (
+	// ContextKeyUserID is the key used to store user ID in a context
+	ContextKeyUserID ContextKey = iota
+)
+
 // Opts used to configure the FlameDB service
 type Opts struct {
 	API            *operations.FlamedbAPI
@@ -136,6 +144,7 @@ func (svc *Service) createRecord(params records.CreateRecordParams, principal *m
 				})
 		}
 		userID = *params.XUserID
+		log.WithField("user_id", userID).Info("Principal updated")
 	}
 
 	if _, err := svc.flame.Get(database.Key{Path: *input.Path}); err == nil {
@@ -195,6 +204,7 @@ func (svc *Service) deleteRecord(params records.DeleteRecordParams, principal *m
 				})
 		}
 		userID = *params.XUserID
+		log.WithField("user_id", userID).Info("Principal updated")
 	}
 
 	record, err := svc.flame.Get(database.Key{ID: params.RecordID})
@@ -292,6 +302,8 @@ func (svc *Service) findRecord(params records.FindRecordParams, principal *model
 
 func (svc *Service) listRecords(params records.ListRecordsParams, principal *models.Principal) middleware.Responder {
 
+	log.Println("listRecords")
+
 	query := database.Query{
 		Offset:              getIntDefault(params.Offset, 0),
 		Limit:               getIntDefault(params.Limit, 100),
@@ -348,12 +360,13 @@ func (svc *Service) updateRecord(params records.UpdateRecordParams, principal *m
 				})
 		}
 		userID = *params.XUserID
+		log.WithField("user_id", userID).Info("Principal updated")
 	}
 
 	propJSON, err := json.Marshal(input.Properties)
 	if err != nil {
 		return records.NewUpdateRecordBadRequest().
-			WithPayload(&models.ValidationError{
+			WithPayload(&models.BadRequest{
 				ErrorType: "ValidationError",
 				Message:   "Invalid properties JSON",
 			})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -35,6 +35,11 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/RecordInput"
+      - name: X-User-ID
+        in: header
+        description: "Override user ID"
+        required: false
+        type: string
       responses:
         200:
           description: "Successfully created"
@@ -153,15 +158,20 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/RecordInput"
+      - name: X-User-ID
+        in: header
+        description: "Override user ID"
+        required: false
+        type: string
       responses:
         200:
           description: "Successfully updated"
           schema:
             $ref: "#/definitions/RecordOutput"
         400:
-          description: "Validation exception"
+          description: "Bad request"
           schema:
-            $ref: "#/definitions/ValidationError"
+            $ref: "#/definitions/BadRequest"
         404:
           description: "Not found"
           schema:
@@ -187,9 +197,18 @@ paths:
         description: "ID of record to be updated"
         required: true
         type: string
+      - name: X-User-ID
+        in: header
+        description: "Override user ID"
+        required: false
+        type: string
       responses:
         200:
           description: "Record deleted"
+        400:
+          description: "Bad request"
+          schema:
+            $ref: "#/definitions/BadRequest"
         404:
           description: "Record not found"
           schema:
@@ -291,12 +310,10 @@ definitions:
     properties:
       user_id:
         type: string
-      name:
+      permissions:
         type: string
-      email:
-        type: string
-      token:
-        type: string
+      is_service:
+        type: boolean
   InternalServerError:
     type: object
     properties:


### PR DESCRIPTION
# Why

Introduce access key based authentication which is useful for providing access to the FlameDB API from other services.

# What

Access keys may be passed via the HTTP basic auth mechanisms.

Keys may be generated with the `flamedb-access-key` command. They are stored in an `access_keys` table in the database.

